### PR TITLE
Fixes bug from 1048 where the local player's bone info would be removed on scene change

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -386,6 +386,16 @@ namespace DBMod
         private static void OnPlayerLeft(IntPtr @this, IntPtr playerPtr)
         {
             Player player = new Player(playerPtr);
+
+            if (player.transform.root.gameObject.name.Contains("[Local]"))
+            {
+#if DEBUG
+                MelonLogger.Log(ConsoleColor.Red, $"Not removing local player info");
+#endif
+                onPlayerLeftDelegate(@this, playerPtr);
+                return;
+            }
+
             if (!_Instance.avatarsInScene.ContainsKey(player.field_Internal_VRCPlayer_0.prop_String_0) && !_Instance.originalSettings.ContainsKey(player.field_Internal_VRCPlayer_0.prop_String_0))
             {
 

--- a/Main.cs
+++ b/Main.cs
@@ -535,6 +535,7 @@ namespace DBMod
         {
             foreach (System.Tuple<GameObject, bool, DynamicBone[], DynamicBoneCollider[], bool> player in avatarsInScene.Values)
             {
+                MelonLogger.Log(ConsoleColor.Red, $"AddAllCollidersToAllPlayers - {player.Item5}");
                 AddCollidersToAllPlayers(player);
                 //AddBonesOfGameObjectToAllPlayers(player);
             }

--- a/Main.cs
+++ b/Main.cs
@@ -545,7 +545,6 @@ namespace DBMod
         {
             foreach (System.Tuple<GameObject, bool, DynamicBone[], DynamicBoneCollider[], bool> player in avatarsInScene.Values)
             {
-                MelonLogger.Log(ConsoleColor.Red, $"AddAllCollidersToAllPlayers - {player.Item5}");
                 AddCollidersToAllPlayers(player);
                 //AddBonesOfGameObjectToAllPlayers(player);
             }


### PR DESCRIPTION
Fixes bug from 1048 where the local player's bone info would be removed on scene change. For some reason OnPlayerLeft is getting called for the local player right after joining a world now. Added a simple check to disable that from removing the local player. Since the mod resets on world change, it shouldn't be needed for the local player anyway.  